### PR TITLE
Fixes access rights information in case of group access rights.

### DIFF
--- a/app/controllers/manage/access_rights_controller.rb
+++ b/app/controllers/manage/access_rights_controller.rb
@@ -6,6 +6,12 @@ class Manage::AccessRightsController < Manage::ApplicationController
                          .access_rights
                          .active
                          .where(user_id: params[:user_ids])
+                         .map {|ar| {
+                           role: ar.role,
+                           user_id: ar.user_id,
+                           inventory_pool_id: ar.inventory_pool_id,
+                           suspended_until: ar.suspended_until}
+                         }
                      else
                        raise 'User ids required'
                      end


### PR DESCRIPTION
Access rights for individual users defined via group access rights are displayed incorrectly. The reason for this is that the returned access rights objects from "/manage/{inventory_pool_id}/access_rights" contain an "ID" property. For group access rights, the ID property includes the ID of the group access rights entry from the database.
Spine will use this as a unique identifier if an ID property is present. However, since all access right objects, of the individual users with the same group access right, have the same ID, only the last one is stored by Spine.
This fix changes the access rights object in the web service response by not including the ID of the group access rights entry. If the ID property is missing, Spine generates its own unique ID for the corresponding access right object.

regards 
Mario

